### PR TITLE
closes #18 adding return button

### DIFF
--- a/app/views/spaces/index.erb
+++ b/app/views/spaces/index.erb
@@ -1,5 +1,12 @@
 <section>
 <h2> Latest Spaces </h2>
+  
+<br/>
+<form method='get' action='/spaces/new'>
+  <button type="submit" name="submit" value="add_space">Add Space</button>
+</form>
+<br/><br/>
+  
 <ul id="spaces">
   <% @spaces.each do |space| %>
     <li>

--- a/app/views/spaces/index.erb
+++ b/app/views/spaces/index.erb
@@ -10,7 +10,7 @@
 <ul id="spaces">
   <% @spaces.each do |space| %>
     <li>
-        <span class='rwd-line'>  <%= space.id %> </span>
+        
       <strong name='name'>Space <%= space.name %></strong>
         <br/>
 
@@ -18,7 +18,7 @@
         <br/>
         <span class='rwd-line'> £ <%= space.rate %> </span>
         <br/>
-        <%= "<a href=\"spaces/#{space.id}\"> See Space</a>" %>
+        <%= "<a href=\"spaces/#{space.id}\" style=\"background-color:lightgreen\"> See Space</a>" %>
     </li>
   <% end %>
 </ul>

--- a/app/views/spaces/new.erb
+++ b/app/views/spaces/new.erb
@@ -17,11 +17,11 @@ Price per night (£)
   </label>
 Available from (DD/MM/YYYY)
   <label for="available_from_date">
-    <input type="text" name="available_from_date" required>
+    <input type="date" name="available_from_date" required>
   </label>
   Available to (DD/MM/YYYY)
   <label for="available_to_date">
-    <input type="text" name="available_to_date" required>
+    <input type="date" name="available_to_date" required>
   </label>
 
   <button type='submit'>List my Space</button>

--- a/app/views/spaces/space.erb
+++ b/app/views/spaces/space.erb
@@ -13,3 +13,6 @@
 <form method='get' action='/spaces/<%= session[:id] %>/update'>
   <button type="submit" name="submit" value="Edit Space">Edit Space</button>
 </form>
+<form action='/spaces'>
+  <button type='submit'>Back to Spaces</button>
+</form>

--- a/spec/features/navigation_loop_spec.rb
+++ b/spec/features/navigation_loop_spec.rb
@@ -1,0 +1,32 @@
+feature 'navigation loop space' do
+  scenario 'host wants to navigate from the current space back to spaces' do
+    sign_up
+    sign_in
+    visit('/spaces/new')
+    fill_in('name', with: 'OneLoop')
+    enter_generic_details
+
+    within 'ul#spaces' do
+      expect(page).to have_content('OneLoop')
+    end
+    
+    visit('/spaces/new')
+    fill_in('name', with: 'TwoLoop')
+    enter_generic_details
+
+    within 'ul#spaces' do
+      expect(page).to have_content('OneLoop')
+      expect(page).to have_content('TwoLoop')
+    end
+
+    first(:link, 'See Space').click
+
+    expect(current_path).to eq('/spaces/4')
+    expect(page).to have_content('OneLoop')
+
+    click_button('Back to Spaces')
+    expect(current_path).to eq('/spaces')
+    expect(page).to have_content('OneLoop')
+
+  end
+end

--- a/spec/features/update_space_spec.rb
+++ b/spec/features/update_space_spec.rb
@@ -3,34 +3,34 @@ feature 'update space' do
     sign_up
     sign_in
     visit('/spaces/new')
-    fill_in('name', with: 'One')
+    fill_in('name', with: 'OneUpdate')
     enter_generic_details
 
     within 'ul#spaces' do
-      expect(page).to have_content('One')
+      expect(page).to have_content('OneUpdate')
     end
     visit('/spaces/new')
-    fill_in('name', with: 'Two')
+    fill_in('name', with: 'TwoUpdate')
     enter_generic_details
 
     within 'ul#spaces' do
-      expect(page).to have_content('One')
-      expect(page).to have_content('Two')
+      expect(page).to have_content('OneUpdate')
+      expect(page).to have_content('TwoUpdate')
     end
 
     first(:link, 'See Space').click
 
-    expect(current_path).to eq('/spaces/4')
-    expect(page).to have_content('One')
+    expect(current_path).to eq('/spaces/6')
+    expect(page).to have_content('OneUpdate')
 
     click_button('Edit Space')
-    expect(current_path).to eq('/spaces/4/update')
+    expect(current_path).to eq('/spaces/6/update')
 
     fill_in('description', with: 'Shoe Box')
     fill_in('rate', with: 100)
 
     click_button('Update my Space')
-    expect(current_path).to eq('/spaces/4')
+    expect(current_path).to eq('/spaces/6')
     expect(page).to have_content('Shoe Box')
 
   end


### PR DESCRIPTION
User can now navigate from 'seeing' a space, back to the list of spaces, both with an update to space information and without.